### PR TITLE
Fix "GET /api/v1/transactions" response_code 반환 타입 수정

### DIFF
--- a/loopchain/rest_server/rest_server.py
+++ b/loopchain/rest_server/rest_server.py
@@ -199,7 +199,7 @@ class Transaction(Resource):
         args = ServerComponents().parser.parse_args()
         response = ServerComponents().get_transaction(args['hash'], get_channel_name_from_args(args))
         tx_data = json.loads('{}')
-        tx_data['response_code'] = str(response.response_code)
+        tx_data['response_code'] = response.response_code
         tx_data['data'] = ""
         if len(response.data) is not 0:
             try:
@@ -316,7 +316,6 @@ class Blocks(Resource):
             block_data['block_data_json'] = json.loads(response.block_data_json)
 
         return block_data
-
 
 
 class RestServer(CommonThread):


### PR DESCRIPTION
https://github.com/caerang/loopchain/blob/master/proxy_rest_api.md 문서에는 "GET /api/v1/transactions"의 반환 타입이 int로 명시되어 있으나 str형으로 반환하고 있어 int 형으로 수정